### PR TITLE
Default condition to true

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,4 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^\.travis\.yml$
+^cran-comments\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
-.Rbuildignore
 inst/doc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ License: GPL-3
 LazyData: true
 Depends:
     R (>= 3.1.2)
-RoxygenNote: 6.1.0
+RoxygenNote: 7.0.2
+Encoding: UTF-8
 Suggests:
     knitr,
     rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+- `feedback()`, `feedbackDanger()`, `feedbackWarning()` and `feedbackSuccess()` now default to `condition = TRUE`; this means you can control their action with an if statement, like `if (input$a < 0) feedbackDanger("a")`
+
 # shinyFeedback 0.1.0
 
 - added basic snackbar notifications

--- a/R/feedback-wrappers.R
+++ b/R/feedback-wrappers.R
@@ -40,7 +40,7 @@
 #'   shinyApp(ui, server)
 #' }
 #' 
-feedbackWarning <- function(inputId, condition, 
+feedbackWarning <- function(inputId, condition = TRUE, 
                             text = "Ye be warned",
                             color = "#F89406", 
                             icon = shiny::icon("warning-sign", lib="glyphicon")) {
@@ -98,7 +98,7 @@ feedbackWarning <- function(inputId, condition,
 #'   shinyApp(ui, server)
 #' }
 #' 
-feedbackDanger <- function(inputId, condition, 
+feedbackDanger <- function(inputId, condition = TRUE, 
                            text = "Danger, turn back!",
                            color = "#d9534f", 
                            icon = shiny::icon("exclamation-sign", lib="glyphicon")) {
@@ -155,7 +155,7 @@ feedbackDanger <- function(inputId, condition,
 #'   shinyApp(ui, server)
 #' }
 #' 
-feedbackSuccess <- function(inputId, condition, 
+feedbackSuccess <- function(inputId, condition = TRUE, 
                             text = NULL,
                             color = "#5cb85c", 
                             icon = shiny::icon("ok", lib="glyphicon")) {

--- a/R/feedback.R
+++ b/R/feedback.R
@@ -44,7 +44,7 @@
 #'   shinyApp(ui, server)
 #' }
 #' 
-feedback <- function(inputId, condition, text = NULL, color = NULL, 
+feedback <- function(inputId, condition = TRUE, text = NULL, color = NULL, 
                      icon = NULL) {
   
   # some argument checks

--- a/man/feedback.Rd
+++ b/man/feedback.Rd
@@ -4,7 +4,7 @@
 \alias{feedback}
 \title{feedback}
 \usage{
-feedback(inputId, condition, text = NULL, color = NULL, icon = NULL)
+feedback(inputId, condition = TRUE, text = NULL, color = NULL, icon = NULL)
 }
 \arguments{
 \item{inputId}{the Shiny input's \code{inputId} argument}

--- a/man/feedbackDanger.Rd
+++ b/man/feedbackDanger.Rd
@@ -6,7 +6,7 @@
 \usage{
 feedbackDanger(
   inputId,
-  condition,
+  condition = TRUE,
   text = "Danger, turn back!",
   color = "#d9534f",
   icon = shiny::icon("exclamation-sign", lib = "glyphicon")

--- a/man/feedbackDanger.Rd
+++ b/man/feedbackDanger.Rd
@@ -4,9 +4,13 @@
 \alias{feedbackDanger}
 \title{feedbackDanger}
 \usage{
-feedbackDanger(inputId, condition, text = "Danger, turn back!",
-  color = "#d9534f", icon = shiny::icon("exclamation-sign", lib =
-  "glyphicon"))
+feedbackDanger(
+  inputId,
+  condition,
+  text = "Danger, turn back!",
+  color = "#d9534f",
+  icon = shiny::icon("exclamation-sign", lib = "glyphicon")
+)
 }
 \arguments{
 \item{inputId}{the Shiny input's \code{inputId} argument}
@@ -53,7 +57,8 @@ if (interactive()) {
 \seealso{
 \code{\link{feedback}}, \code{\link{feedbackWarning}}, \code{\link{feedbackSuccess}}
 
-Other feedback wrappers: \code{\link{feedbackSuccess}},
-  \code{\link{feedbackWarning}}
+Other feedback wrappers: 
+\code{\link{feedbackSuccess}()},
+\code{\link{feedbackWarning}()}
 }
 \concept{feedback wrappers}

--- a/man/feedbackSuccess.Rd
+++ b/man/feedbackSuccess.Rd
@@ -6,7 +6,7 @@
 \usage{
 feedbackSuccess(
   inputId,
-  condition,
+  condition = TRUE,
   text = NULL,
   color = "#5cb85c",
   icon = shiny::icon("ok", lib = "glyphicon")

--- a/man/feedbackSuccess.Rd
+++ b/man/feedbackSuccess.Rd
@@ -4,8 +4,13 @@
 \alias{feedbackSuccess}
 \title{feedbackSuccess}
 \usage{
-feedbackSuccess(inputId, condition, text = NULL, color = "#5cb85c",
-  icon = shiny::icon("ok", lib = "glyphicon"))
+feedbackSuccess(
+  inputId,
+  condition,
+  text = NULL,
+  color = "#5cb85c",
+  icon = shiny::icon("ok", lib = "glyphicon")
+)
 }
 \arguments{
 \item{inputId}{the Shiny input's \code{inputId} argument}
@@ -52,7 +57,8 @@ if (interactive()) {
 \seealso{
 \code{\link{feedback}}, \code{\link{feedbackDanger}}, \code{\link{feedbackSuccess}}
 
-Other feedback wrappers: \code{\link{feedbackDanger}},
-  \code{\link{feedbackWarning}}
+Other feedback wrappers: 
+\code{\link{feedbackDanger}()},
+\code{\link{feedbackWarning}()}
 }
 \concept{feedback wrappers}

--- a/man/feedbackWarning.Rd
+++ b/man/feedbackWarning.Rd
@@ -4,9 +4,13 @@
 \alias{feedbackWarning}
 \title{feedbackWarning}
 \usage{
-feedbackWarning(inputId, condition, text = "Ye be warned",
-  color = "#F89406", icon = shiny::icon("warning-sign", lib =
-  "glyphicon"))
+feedbackWarning(
+  inputId,
+  condition,
+  text = "Ye be warned",
+  color = "#F89406",
+  icon = shiny::icon("warning-sign", lib = "glyphicon")
+)
 }
 \arguments{
 \item{inputId}{the Shiny input's \code{inputId} argument}
@@ -53,7 +57,8 @@ if (interactive()) {
 \seealso{
 \code{\link{feedback}}, \code{\link{feedbackDanger}}, \code{\link{feedbackSuccess}}
 
-Other feedback wrappers: \code{\link{feedbackDanger}},
-  \code{\link{feedbackSuccess}}
+Other feedback wrappers: 
+\code{\link{feedbackDanger}()},
+\code{\link{feedbackSuccess}()}
 }
 \concept{feedback wrappers}

--- a/man/feedbackWarning.Rd
+++ b/man/feedbackWarning.Rd
@@ -6,7 +6,7 @@
 \usage{
 feedbackWarning(
   inputId,
-  condition,
+  condition = TRUE,
   text = "Ye be warned",
   color = "#F89406",
   icon = shiny::icon("warning-sign", lib = "glyphicon")

--- a/man/snackbar.Rd
+++ b/man/snackbar.Rd
@@ -4,8 +4,7 @@
 \alias{snackbar}
 \title{snackbar}
 \usage{
-snackbar(id, message, includeRemoveButton = TRUE, class = "",
-  style = "")
+snackbar(id, message, includeRemoveButton = TRUE, class = "", style = "")
 }
 \arguments{
 \item{id}{A length 1 character vector.  The unique id of the snackbar. This needs to match up with

--- a/man/snackbarDanger.Rd
+++ b/man/snackbarDanger.Rd
@@ -21,7 +21,8 @@ This is a wrapper for \code{\link{snackbar}}.  It provides red danger/error styl
 \seealso{
 \code{\link{showSnackbar}}
 
-Other snackbar wrappers: \code{\link{snackbarSuccess}},
-  \code{\link{snackbarWarning}}
+Other snackbar wrappers: 
+\code{\link{snackbarSuccess}()},
+\code{\link{snackbarWarning}()}
 }
 \concept{snackbar wrappers}

--- a/man/snackbarSuccess.Rd
+++ b/man/snackbarSuccess.Rd
@@ -21,7 +21,8 @@ This is a wrapper for \code{\link{snackbar}}.  It provides green success styling
 \seealso{
 \code{\link{showSnackbar}}
 
-Other snackbar wrappers: \code{\link{snackbarDanger}},
-  \code{\link{snackbarWarning}}
+Other snackbar wrappers: 
+\code{\link{snackbarDanger}()},
+\code{\link{snackbarWarning}()}
 }
 \concept{snackbar wrappers}

--- a/man/snackbarWarning.Rd
+++ b/man/snackbarWarning.Rd
@@ -21,7 +21,8 @@ This is a wrapper for \code{\link{snackbar}}.  It provides yellow warning stylin
 \seealso{
 \code{\link{showSnackbar}}
 
-Other snackbar wrappers: \code{\link{snackbarDanger}},
-  \code{\link{snackbarSuccess}}
+Other snackbar wrappers: 
+\code{\link{snackbarDanger}()},
+\code{\link{snackbarSuccess}()}
 }
 \concept{snackbar wrappers}

--- a/shinyFeedback.Rproj
+++ b/shinyFeedback.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
(Depends on #16)

This shouldn't change any existing usage, but allows you to bring the `if` statement outside of the feedback functions, e.g.

```R
if (input$a > 0) feedbackDanger("a")
```

It might also be worth switching the order of the `condition` and `text` arguments so that you could write:

```R
if (input$a > 0) feedbackDanger("a", "Must be positive")
```

That's potentially a breaking change if you think people have been depending on positional matching, but I'd be happy to make it if you wanted.