### PR TITLE
Revert input border instead of removing style attr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyFeedback 0.2.0.9000
 
+- bug fix to maintain all input styles other than the border style applied by
+shinyFeedback when feedback is removed #36
 
 # shinyFeedback 0.2.0
 

--- a/inst/assets/js/shinyfeedback.js
+++ b/inst/assets/js/shinyfeedback.js
@@ -48,7 +48,7 @@
       var obj = inputObject;
       
       obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.input.css("border", '');
       
       $("#" + message.inputId + "-icon").remove();
       

--- a/inst/assets/js/shinyfeedback.js
+++ b/inst/assets/js/shinyfeedback.js
@@ -108,8 +108,8 @@
       
       var obj = inputObject;
       
-      obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.label.css("color", "");
+      obj.input.css("border", "");
       
       $("#" + message.inputId + "-icon").remove();
       
@@ -188,8 +188,8 @@
       
       var obj = inputObject;
       
-      obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.label.css("color", "");
+      obj.input.css("border", "");
       
       $("#" + message.inputId + "-icon").remove();
       
@@ -249,8 +249,8 @@
       var obj = inputObject;
       
       inputObject.formGroup.removeClass("has-feedback");
-      obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.label.css("color", "");
+      obj.input.css("border", "");
       $("#" + message.inputId + "-icon").remove();
       $("#" + message.inputId + "-text").remove();
     }
@@ -306,8 +306,8 @@
       var obj = inputObject;
       
       inputObject.formGroup.removeClass("has-feedback");
-      obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.label.css("color", "");
+      obj.input.css("border", "");
       $("#" + message.inputId + "-icon").remove();
       $("#" + message.inputId + "-text").remove();
     }
@@ -366,7 +366,7 @@
       
       inputObject.formGroup.removeClass("has-feedback");
       obj.label.css("color", "");
-      obj.inputDiv.removeAttr("style");
+      obj.inputDiv.css("border", "");
       $("#" + message.inputId + "-icon").remove();
       $("#" + message.inputId + "-text").remove();
     }
@@ -425,8 +425,8 @@
       
       var obj = inputObject;
       
-      obj.label.css("color", '');
-      obj.input.removeAttr("style");
+      obj.label.css("color", "");
+      obj.input.css("border", "");
       
       $("#" + message.inputId + "-icon").remove();
       

--- a/inst/examples/supported_inputs_app/ui.R
+++ b/inst/examples/supported_inputs_app/ui.R
@@ -26,7 +26,8 @@ fluidPage(
     textAreaInput(
       inputId = "myTextAreaInput",
       label = "Success if > 10 chars",
-      value = "This is a successful text area input value"
+      value = "This is a successful text area input value",
+      height = "200px"
     ),
     
     h2("dateRangeInput"),


### PR DESCRIPTION
PR to resolve issue #36 
- For `textInputFeedback`, revert the `border` style instead of removing the entire `style` attribute