### PR TITLE
support shinyWidgets textInputIcon input binding name

### DIFF
--- a/inst/assets/js/shinyfeedback.js
+++ b/inst/assets/js/shinyfeedback.js
@@ -394,7 +394,8 @@
     {name: "shinyWidgets.pickerInput", feedback: pickerInputFeedback},
     {name: "shinyWidgets.autonumericInput", feedback: numericInputFeedback},
     {name: "shiny.fileInputBinding", feedback: fileInputFeedback},
-    {name: "shinyWidgets.textInputIcon", feedback: shinyWidgetsTextInputIcon}
+    {name: "shinyWidgets.textInputIcon", feedback: shinyWidgetsTextInputIcon},
+    {name: "shinyWidgets.numericInputIcon", feedback: shinyWidgetsTextInputIcon}
   ];
   
   // from https://github.com/daattali/advanced-shiny/blob/master/update-input/www/app-shinyjs.js

--- a/inst/assets/js/shinyfeedback.js
+++ b/inst/assets/js/shinyfeedback.js
@@ -127,6 +127,45 @@
   });
   
   
+    // shinyWidgetsTextInputIcon functions
+  var shinyWidgetsTextInputIcon = $.extend({}, baseInputFeedback, {
+    "setColor": function(inputObject, message) {
+      if (message.color) {
+        inputObject.label.css("color", message.color);
+        inputObject.formGroup.find('.sw-input-icon').css("border", "1px solid " + message.color);
+        inputObject.formGroup.find('span').css("color", message.color);
+        inputObject.input.css("border", "1px solid " + message.color);
+      } else {
+        inputObject.label.css("color", "");
+        inputObject.formGroup.find('.sw-input-icon').css("border", "");
+        inputObject.formGroup.find('span').css("color", "");
+        inputObject.input.css("border", "");
+      }
+    },
+    "setText": function(inputObject, message) {
+      if (message.text) {
+        $("<div id='" + message.inputId + "-text'><p style='color: " + message.color + "; position: " + message.textPosition + "; margin-top: 0px;'>"+ message.text +"</p>").insertAfter(inputObject.inputDiv);
+      } else {
+        $("#" + message.inputId + "-text").remove();
+      }
+    },
+    "find": function(inputId) {
+      var input = findInput(inputId);
+      var formGroup = input.closest(".form-group");
+      var inputDiv = input.parent().parent()
+      var label = inputDiv.children("label");
+    
+      return {
+        "input": input,
+        "inputDiv": inputDiv,
+        "label": label,
+        "formGroup": formGroup
+      };
+    },
+    
+  });
+  
+  
   // selectInputFeedback functions
   var selectInputFeedback = $.extend({}, baseInputFeedback, {
     "find": function(inputId) {
@@ -354,7 +393,8 @@
     {name: "shiny.pickerInput", feedback: pickerInputFeedback},
     {name: "shinyWidgets.pickerInput", feedback: pickerInputFeedback},
     {name: "shinyWidgets.autonumericInput", feedback: numericInputFeedback},
-    {name: "shiny.fileInputBinding", feedback: fileInputFeedback}
+    {name: "shiny.fileInputBinding", feedback: fileInputFeedback},
+    {name: "shinyWidgets.textInputIcon", feedback: shinyWidgetsTextInputIcon}
   ];
   
   // from https://github.com/daattali/advanced-shiny/blob/master/update-input/www/app-shinyjs.js

--- a/inst/assets/js/shinyfeedback.js
+++ b/inst/assets/js/shinyfeedback.js
@@ -144,7 +144,7 @@
     },
     "setText": function(inputObject, message) {
       if (message.text) {
-        $("<div id='" + message.inputId + "-text'><p style='color: " + message.color + "; position: " + message.textPosition + "; margin-top: 0px;'>"+ message.text +"</p>").insertAfter(inputObject.inputDiv);
+        $("<span id='" + message.inputId + "-text' style='position: absolute;color: " + message.color +"; margin-top: 0px;'>"+ message.text +"</span>").insertAfter( $("#" + message.inputId).parent());
       } else {
         $("#" + message.inputId + "-text").remove();
       }


### PR DESCRIPTION
I work with many different form fields also like shinywidget and shinyfeedback is often in use. We use R/Shiny for an internal project of a big company and shinyfeedback is a big help. With this PR I want to add support for `textInputIcon` of `shinyWidget`. Maybe in  the future there is more required. I would guess so.

Let me know what you need for this PR. You can see it in action here:

![shiny_widget](https://user-images.githubusercontent.com/21102167/194316141-dbe5cb7a-95cc-44b1-832f-e62709a7ccf1.gif)
